### PR TITLE
Fix Spectre.Markup escaping and upgrade dependencies

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,10 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(dotnet test:*)",
+      "Bash(dotnet --list-sdks)",
+      "Bash(gh issue:*)",
+      "WebFetch(domain:github.com)"
+    ]
+  }
+}

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -7,14 +7,14 @@
   <ItemGroup>
     <PackageVersion Include="BenchmarkDotNet" Version="0.15.8" />
     <PackageVersion Include="BenchmarkDotNet.Diagnostics.Windows" Version="0.15.8" />
-    <PackageVersion Include="coverlet.collector" Version="6.0.4" PrivateAssets="all">
+    <PackageVersion Include="coverlet.collector" Version="8.0.1" PrivateAssets="all">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageVersion>
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.0.0" />
-    <PackageVersion Include="Nerdbank.GitVersioning" Version="3.8.118" PrivateAssets="all" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
+    <PackageVersion Include="Nerdbank.GitVersioning" Version="3.9.50" PrivateAssets="all" />
     <PackageVersion Include="Shouldly" Version="4.3.0" />
-    <PackageVersion Include="Spectre.Console" Version="0.51.1" />
-    <PackageVersion Include="Spectre.Console.Testing" Version="0.51.1" />
+    <PackageVersion Include="Spectre.Console" Version="0.55.0" />
+    <PackageVersion Include="Spectre.Console.Testing" Version="0.55.0" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" PrivateAssets="all">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@
 
 ```bash
 > dotnet --list-sdks
-10.0.103 [/usr/share/dotnet/sdk]
+10.0.104 [/usr/share/dotnet/sdk]
 
 > git --version
 git version 2.53.0

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "10.0.103",
+    "version": "10.0.104",
     "rollForward": "minor",
     "allowPrerelease": true
   }

--- a/src/Lolcat/Rainbow.cs
+++ b/src/Lolcat/Rainbow.cs
@@ -5,20 +5,29 @@
 /// </summary>
 public sealed class Rainbow
 {
+    private readonly bool _escape;
+
     public Rainbow(RainbowStyle? rainbowStyle = null)
     {
         RainbowStyle = rainbowStyle ?? new RainbowStyle();
-        Console = RainbowStyle.EscapeSequence == EscapeSequence.Ansi
-            ? new SystemConsole()
-            : new SpectreConsole();
-    }
 
-    public static Rainbow WithStyle(RainbowStyle rainbowStyle) => new(rainbowStyle);
+        if (RainbowStyle.EscapeSequence == EscapeSequence.Ansi)
+        {
+            Console = new SystemConsole();
+        }
+        else
+        {
+            Console = new SpectreConsole();
+            _escape = true;
+        }
+    }
 
     internal Rainbow(IConsole console, RainbowStyle? rainbowStyle = null) : this(rainbowStyle)
     {
         Console = console;
     }
+
+    public static Rainbow WithStyle(RainbowStyle rainbowStyle) => new(rainbowStyle);
 
     public IConsole Console { get; }
 
@@ -114,9 +123,9 @@ public sealed class Rainbow
             var pair = i + 1 < line.Length && char.IsSurrogatePair(line[i], line[i + 1]);
             var @char = pair ? line[i] + line[++i].ToString() : line[i].ToString();
 
-            if (RainbowStyle.EscapeSequence == EscapeSequence.Spectre)
+            if (_escape)
             {
-                @char = @char.EscapeMarkup();
+                @char = Spectre.Console.Markup.Escape(@char);
             }
 
             Line.AppendFormat(Console.Format, red, green, blue, @char);

--- a/tests/Lolcat.Tests/RainbowTests.cs
+++ b/tests/Lolcat.Tests/RainbowTests.cs
@@ -102,4 +102,21 @@ public class RainbowTests : TestBase
         Should.NotThrow(() =>
             rainbow.WriteLineWithMarkup(Resources.SpectreTextWithEscapeCharacters));
     }
+
+    [Fact]
+    public void Markup_WithSpectreEscapeSequence_EscapesMarkupSpecialCharacters()
+    {
+        // Regression test for https://github.com/si618/lolcat/issues/152
+        // StringExtensions.EscapeMarkup was moved from Spectre.Console.dll to
+        // Spectre.Console.Ansi.dll in 0.55.0, causing MissingMethodException in
+        // published binaries. Fix: use Markup.Escape() which stays in Spectre.Console.dll.
+        var style = new RainbowStyle(EscapeSequence: EscapeSequence.Spectre, Seed: Seed);
+        var rainbow = new Rainbow(style);
+
+        var markup = rainbow.Markup("[hello]");
+
+        // Output must be valid Spectre markup — i.e., [ and ] were escaped via Markup.Escape.
+        // new Markup() throws if the string contains unescaped markup-special characters.
+        Should.NotThrow(() => new Markup(markup));
+    }
 }


### PR DESCRIPTION
Fixes #152

## Changes
- Fix Spectre.Markup escaping issues
- Upgrade to .NET SDK 10.0.104
- Add local CLA settings
- Upgrade dependencies: coverlet.collector, Microsoft.NET.Test.Sdk, Nerdbank.GitVersioning, and Spectre.Console