### PR TITLE
Update license metadata to use `PackageLicenseExpression` with Apache-2.0

### DIFF
--- a/src/Lolcat/Lolcat.csproj
+++ b/src/Lolcat/Lolcat.csproj
@@ -9,7 +9,7 @@
     <RepositoryUrl>https://github.com/si618/lolcat</RepositoryUrl>
     <Copyright>Simon McKenna</Copyright>
     <PackageProjectUrl>https://github.com/si618/lolcat</PackageProjectUrl>
-    <PackageLicense>https://github.com/si618/lolcat/LICENSE</PackageLicense>
+    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <RepositoryType>git</RepositoryType>
   </PropertyGroup>
 


### PR DESCRIPTION
Update license metadata in the project to use `PackageLicenseExpression` with Apache-2.0.